### PR TITLE
Reconnect to Redis after job finishes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,6 +323,10 @@ impl Queue {
             if let Status::RUNNING(_) = job.status {
                 job.status = Status::LOST
             }
+
+            // Reconnect to Redis in case job ran for longer than
+            // Redis connection timeout
+            let conn = self.redis_connection()?;
             let _: () = conn.set_ex(&key, serde_json::to_string(&job)?, expire)?;
 
             if fall && job.status == Status::LOST {


### PR DESCRIPTION
If the job runs for a very long time the Redis connection can timeout,
so we should reconnect before trying to update the status on Redis.